### PR TITLE
Set up test infra

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  SETUP_K3D_VERSION: 'v5.6.0'
+
 jobs:
 
   build:
@@ -29,8 +32,11 @@ jobs:
     - name: Provision k3d Cluster
       uses: AbsaOSS/k3d-action@v2
       with:
+        k3d-version: ${{ env.SETUP_K3D_VERSION }}
         cluster-name: "epinio"
         args: >-
+          --agents 1
+          --network "nw01"
           --image docker.io/rancher/k3s:v1.28.2+k3s1
 
     - name: Set up test infra

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,13 +34,13 @@ jobs:
           --image docker.io/rancher/k3s:v1.28.2-k3s1
 
     - name: Set up test infra
-      run: ./tests/set_up_cluster.sh
+      run: make infra-setup
 
     - name: Test
       run: make test
 
     - name: Tear down test infra
-      run: k3d cluster delete epinio
+      run: make infra-teardown
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         version: v1.54
 
     - name: Build
-      run: go build -v ./...
+      run: make build
 
     - name: Provision k3d Cluster
       uses: AbsaOSS/k3d-action@v2
@@ -37,7 +37,7 @@ jobs:
       run: ./tests/set_up_cluster.sh
 
     - name: Test
-      run: go test -v ./...
+      run: make test
 
     - name: Tear down test infra
       run: k3d cluster delete epinio

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         args: >-
           --agents 1
           --network "nw01"
-          --image docker.io/rancher/k3s:v1.28.2+k3s1
+          --image docker.io/rancher/k3s:v1.28.2-k3s1
 
     - name: Set up test infra
       run: ./tests/set_up_cluster.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  SETUP_K3D_VERSION: 'v5.6.0'
-
 jobs:
 
   build:
@@ -32,11 +29,8 @@ jobs:
     - name: Provision k3d Cluster
       uses: AbsaOSS/k3d-action@v2
       with:
-        k3d-version: ${{ env.SETUP_K3D_VERSION }}
         cluster-name: "epinio"
         args: >-
-          --agents 1
-          --network "nw01"
           --image docker.io/rancher/k3s:v1.28.2-k3s1
 
     - name: Set up test infra

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,21 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    - name: Provision k3d Cluster
+      uses: AbsaOSS/k3d-action@v2
+      with:
+        cluster-name: "epinio"
+        args: >-
+          --image docker.io/rancher/k3s:v1.28.2+k3s1
+
+    - name: Set up test infra
+      run: ./tests/set_up_cluster.sh
+
     - name: Test
       run: go test -v ./...
+
+    - name: Tear down test infra
+      run: k3d cluster delete epinio
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ export LDFLAGS += -X github.com/enrichman/kubectl-epinio/internal/cmd.Version=$(
 build:
 	go build -v -ldflags '$(LDFLAGS)' -o output/ ./...
 
+infra-setup:
+	./tests/set_up_cluster.sh
+
+infra-teardown:
+	k3d cluster delete epinio
+
 lint:
 	golangci-lint run
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@
 
 [![CI](https://github.com/enrichman/kubectl-epinio/actions/workflows/main.yml/badge.svg)](https://github.com/enrichman/kubectl-epinio/actions/workflows/main.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/enrichman/kubectl-epinio)](https://goreportcard.com/report/github.com/enrichman/kubectl-epinio)
+
+## Testing
+
+Run the following:
+1. `make infra-setup`
+2. `make test`
+3. (optional) `make infra-teardown`

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.8.4
 	k8s.io/cli-runtime v0.28.3
 	k8s.io/client-go v0.28.3
 )
@@ -11,6 +12,7 @@ require (
 require (
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	gopkg.in/evanphx/json-patch.v5 v5.7.0 // indirect
 )

--- a/internal/cli/epinio_test.go
+++ b/internal/cli/epinio_test.go
@@ -1,0 +1,117 @@
+package cli_test
+
+import (
+	"fmt"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGet(t *testing.T) {
+	cmd := exec.Command(
+		cmdExecPath(t),
+		"get",
+	)
+
+	out, err := cmd.Output()
+	assert.NoError(t, err)
+
+	assert.Contains(t, string(out), "Usage:")
+}
+
+func TestGetUser(t *testing.T) {
+	testCases := []struct {
+		name            string
+		args            []string
+		expectedEntries []string
+		expectErr       bool
+	}{
+		{
+			name: "get all users",
+			args: []string{},
+			expectedEntries: []string{
+				"admin",
+				"admin@epinio.io",
+				"epinio",
+			},
+		},
+		{
+			name: "get all users",
+			args: []string{},
+			expectedEntries: []string{
+				"admin",
+				"admin@epinio.io",
+				"epinio",
+			},
+		},
+		{
+			name: "get single user with exact match",
+			args: []string{"epinio"},
+			expectedEntries: []string{
+				"epinio",
+			},
+		},
+		{
+			name:            "get nonexistent user",
+			args:            []string{"nothere"},
+			expectedEntries: []string{},
+		},
+		{
+			name:            "get multiple users with exact matches",
+			args:            []string{"epinio", "admin"},
+			expectedEntries: []string{"admin", "epinio"},
+		},
+		{
+			name:            "get multiple users with single exact match",
+			args:            []string{"epinio", "nothere"},
+			expectedEntries: []string{"epinio"},
+		},
+	}
+
+	for _, usersArg := range []string{"user", "users"} {
+		for _, tc := range testCases {
+			t.Run(fmt.Sprintf("%s/%s", tc.name, usersArg), func(t *testing.T) {
+				args := []string{"get", usersArg}
+				args = append(args, tc.args...)
+
+				cmd := exec.Command(cmdExecPath(t), args...)
+
+				out, err := cmd.Output()
+				assert.NoError(t, err)
+
+				entries := strings.Split(string(out), "\n")
+				entries = entries[:len(entries)-1] // The last entry is empty
+
+				expectedEntries := []string{"USERNAME"} // header
+				expectedEntries = append(expectedEntries, tc.expectedEntries...)
+
+				assert.Equal(t, len(expectedEntries), len(entries))
+
+				for i := range tc.expectedEntries {
+					assert.Equal(t, expectedEntries[i], entries[i])
+				}
+			})
+		}
+	}
+}
+
+// getGitRepoRoot returns the root of the git repository in which it is executed.
+func getGitRepoRoot(t *testing.T) string {
+	cmd := exec.Command(
+		"git",
+		"rev-parse",
+		"--show-toplevel",
+	)
+	root, err := cmd.Output()
+	assert.NoError(t, err)
+
+	return strings.TrimRight(string(root), "\n")
+}
+
+// cmdExecPath returns the path to the kubectl-epinio command binary.
+func cmdExecPath(t *testing.T) string {
+	return path.Join(getGitRepoRoot(t), "output", "kubectl-epinio")
+}

--- a/internal/cli/epinio_test.go
+++ b/internal/cli/epinio_test.go
@@ -85,13 +85,18 @@ func TestGetUser(t *testing.T) {
 				entries := strings.Split(string(out), "\n")
 				entries = entries[:len(entries)-1] // The last entry is empty
 
-				expectedEntries := []string{"USERNAME"} // header
-				expectedEntries = append(expectedEntries, tc.expectedEntries...)
+				assert.True(t, len(entries) > 0)
 
-				assert.Equal(t, len(expectedEntries), len(entries))
+				assert.Equal(t, "USERNAME", entries[0]) // header
 
-				for i := range tc.expectedEntries {
-					assert.Equal(t, expectedEntries[i], entries[i])
+				foundEntries := make(map[string]struct{}, len(entries))
+				for _, entry := range entries {
+					foundEntries[entry] = struct{}{}
+				}
+
+				for _, expected := range tc.expectedEntries {
+					_, found := foundEntries[expected]
+					assert.True(t, found)
 				}
 			})
 		}

--- a/tests/install_epinio.sh
+++ b/tests/install_epinio.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cluster_name=${1-epinio}
+namespace=${2-epinio}
+
+external_ip="$(kubectl get svc -n kube-system traefik -o jsonpath={@.status.loadBalancer.ingress})"
+external_ip=$(echo $external_ip | grep -Eo --color=never '([0-9]{1,3}.){3}[0-9]{1,3}')
+
+helm repo add epinio https://epinio.github.io/helm-charts
+helm repo update
+helm upgrade --install epinio epinio/epinio --namespace $namespace --create-namespace \
+    --set global.domain=$external_ip.omg.howdoi.website \
+    --wait
+
+k3d kubeconfig get $cluster_name

--- a/tests/set_up_cluster.sh
+++ b/tests/set_up_cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -uxo pipefail
 
 cluster_name=${1-epinio}
 namespace=${2-epinio}

--- a/tests/set_up_cluster.sh
+++ b/tests/set_up_cluster.sh
@@ -5,7 +5,12 @@ set -euxo pipefail
 cluster_name=${1-epinio}
 namespace=${2-epinio}
 
-k3d cluster create $cluster_name -p '8080:80@loadbalancer' -p '8443:443@loadbalancer' --wait
+k3d cluster list $cluster_name &>/dev/null
+if [ $? -eq 1 ]; then # cluster does not exist
+	k3d cluster create $cluster_name -p '8080:80@loadbalancer' -p '8443:443@loadbalancer' --wait
+else
+	echo "Cluster $cluster_name already exists. Skipping creation..."
+fi
 
 # Ingress controller setup is not necessary, as k3d installs Traefik
 

--- a/tests/set_up_cluster.sh
+++ b/tests/set_up_cluster.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+cluster_name=${1-epinio}
+namespace=${2-epinio}
+
+k3d cluster create $cluster_name -p '8080:80@loadbalancer' -p '8443:443@loadbalancer' --wait
+
+# Ingress controller setup is not necessary, as k3d installs Traefik
+
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager  \
+    --set installCRDs=true \
+    --set extraArgs={--enable-certificate-owner-ref=true} \
+    --create-namespace \
+    --wait
+
+# Dynamic storage provisioner setup is not necessary either, as k3d installs the `local-path` provisioner
+
+./$(dirname $0)/install_epinio.sh $cluster_name $namespace


### PR DESCRIPTION
This provides new scripts to set up test infrastructure to run end-to-end tests against Epinio:
* `./tests/install_epinio.sh` which installs Epinio via Helm
* `./tests/set_up_cluster.sh` which creates a cluster if it does not already exist, then installs `cert-manager` and calls `./tests/install_epinio.sh`

The main CI workflow now calls the cluster setup script to spin up test infra before running test suites.
End-to-end tests are now available for the `get user[s]` command as a first step of improving code coverage.