### PR TITLE
Add delete commands for roles and users

### DIFF
--- a/internal/cli/cmd/delete.go
+++ b/internal/cli/cmd/delete.go
@@ -20,7 +20,7 @@ func NewDeleteCmd(epinioCLI *cli.EpinioCLI) *cobra.Command {
 }
 
 func NewDeleteUserCmd(epinioCLI *cli.EpinioCLI) *cobra.Command {
-	var interactive bool
+	var noConfirm bool
 
 	deleteUserCmd := &cobra.Command{
 		Use:               "user <username>",
@@ -32,17 +32,17 @@ func NewDeleteUserCmd(epinioCLI *cli.EpinioCLI) *cobra.Command {
 			ctx := c.Context()
 			username := args[0]
 
-			return epinioCLI.DeleteUser(ctx, username, interactive)
+			return epinioCLI.DeleteUser(ctx, username, noConfirm)
 		},
 	}
 
-	deleteUserCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "interactive deletion (prompt for confirmation)")
+	deleteUserCmd.Flags().BoolVarP(&noConfirm, "no-confirm", "y", false, "delete without confirmation")
 
 	return deleteUserCmd
 }
 
 func NewDeleteRoleCmd(epinioCLI *cli.EpinioCLI) *cobra.Command {
-	var interactive bool
+	var noConfirm bool
 
 	deleteRoleCmd := &cobra.Command{
 		Use:               "role <role_id>",
@@ -54,11 +54,11 @@ func NewDeleteRoleCmd(epinioCLI *cli.EpinioCLI) *cobra.Command {
 			ctx := c.Context()
 			id := args[0]
 
-			return epinioCLI.DeleteRole(ctx, id, interactive)
+			return epinioCLI.DeleteRole(ctx, id, noConfirm)
 		},
 	}
 
-	deleteRoleCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "interactive deletion (prompt for confirmation)")
+	deleteRoleCmd.Flags().BoolVarP(&noConfirm, "no-confirm", "y", false, "deletion without confirmation")
 
 	return deleteRoleCmd
 }

--- a/internal/cli/cmd/delete.go
+++ b/internal/cli/cmd/delete.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"github.com/enrichman/kubectl-epinio/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+func NewDeleteCmd(epinioCLI *cli.EpinioCLI) *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete an Epinio resource [user/role]",
+	}
+
+	deleteCmd.AddCommand(
+		NewDeleteUserCmd(epinioCLI),
+		NewDeleteRoleCmd(epinioCLI),
+	)
+
+	return deleteCmd
+}
+
+func NewDeleteUserCmd(epinioCLI *cli.EpinioCLI) *cobra.Command {
+	var interactive bool
+
+	deleteUserCmd := &cobra.Command{
+		Use:               "user <username>",
+		Short:             "Delete a user",
+		Example:           `kubectl epinio delete user "foo@bar.io"`,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: NoFileCompletions,
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			username := args[0]
+
+			return epinioCLI.DeleteUser(ctx, username, interactive)
+		},
+	}
+
+	deleteUserCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "interactive deletion (prompt for confirmation)")
+
+	return deleteUserCmd
+}
+
+func NewDeleteRoleCmd(epinioCLI *cli.EpinioCLI) *cobra.Command {
+	var interactive bool
+
+	deleteRoleCmd := &cobra.Command{
+		Use:               "role <role_id>",
+		Short:             "Delete a role",
+		Example:           `kubectl epinio delete role "read_role"`,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: NoFileCompletions,
+		RunE: func(c *cobra.Command, args []string) error {
+			ctx := c.Context()
+			id := args[0]
+
+			return epinioCLI.DeleteRole(ctx, id, interactive)
+		},
+	}
+
+	deleteRoleCmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "interactive deletion (prompt for confirmation)")
+
+	return deleteRoleCmd
+}

--- a/internal/cli/cmd/root.go
+++ b/internal/cli/cmd/root.go
@@ -45,6 +45,7 @@ func NewRootCmd(streams genericiooptions.IOStreams) (*cobra.Command, error) {
 		NewDescribeCmd(epinioCLI),
 		NewEditCmd(epinioCLI),
 		NewCreateCmd(epinioCLI),
+		NewDeleteCmd(epinioCLI),
 	)
 
 	// Uncomment to add some kubectl flags

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 )
 
-// DeleteUser deletes a user by username, after asking for confirmation if interactive resolves to `true`.
-func (e *EpinioCLI) DeleteUser(ctx context.Context, username string, interactive bool) error {
-	if interactive {
+// DeleteUser deletes a user by username, after asking for confirmation if noConfirm resolves to `false`.
+func (e *EpinioCLI) DeleteUser(ctx context.Context, username string, noConfirm bool) error {
+	if !noConfirm {
 		confirm, err := promptConfirmation("Delete? [y/n] ")
 		if err != nil {
 			return err
@@ -28,9 +28,9 @@ func (e *EpinioCLI) DeleteUser(ctx context.Context, username string, interactive
 	return nil
 }
 
-// DeleteRole deletes a role by id, after asking for confirmation if interactive resolves to `true`.
-func (e *EpinioCLI) DeleteRole(ctx context.Context, id string, interactive bool) error {
-	if interactive {
+// DeleteRole deletes a role by id, after asking for confirmation if noConfirm resolves to `false`.
+func (e *EpinioCLI) DeleteRole(ctx context.Context, id string, noConfirm bool) error {
+	if !noConfirm {
 		confirm, err := promptConfirmation("Delete? [y/n] ")
 		if err != nil {
 			return err

--- a/internal/cli/delete.go
+++ b/internal/cli/delete.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+)
+
+// DeleteUser deletes a user by username, after asking for confirmation if interactive resolves to `true`.
+func (e *EpinioCLI) DeleteUser(ctx context.Context, username string, interactive bool) error {
+	if interactive {
+		confirm, err := promptConfirmation("Delete? [y/n] ")
+		if err != nil {
+			return err
+		}
+
+		if !confirm {
+			fmt.Println("aborted!")
+			return nil
+		}
+	}
+
+	if err := e.KubeClient.DeleteUser(ctx, username); err != nil {
+		return err
+	}
+
+	fmt.Println("User deleted!")
+
+	return nil
+}
+
+// DeleteRole deletes a role by id, after asking for confirmation if interactive resolves to `true`.
+func (e *EpinioCLI) DeleteRole(ctx context.Context, id string, interactive bool) error {
+	if interactive {
+		confirm, err := promptConfirmation("Delete? [y/n] ")
+		if err != nil {
+			return err
+		}
+
+		if !confirm {
+			fmt.Println("aborted!")
+			return nil
+		}
+	}
+
+	if err := e.KubeClient.DeleteRole(ctx, id); err != nil {
+		return err
+	}
+
+	fmt.Println("Role deleted!")
+
+	return nil
+}

--- a/pkg/epinio/epinio.go
+++ b/pkg/epinio/epinio.go
@@ -135,3 +135,12 @@ func (k *KubeClient) CreateUser(ctx context.Context, user User) error {
 	_, err := secretClient.Create(ctx, userSecret, metav1.CreateOptions{})
 	return err
 }
+
+// DeleteUser deletes a user by username.
+func (k *KubeClient) DeleteUser(ctx context.Context, username string) error {
+	secretClient := k.kube.CoreV1().Secrets("epinio")
+
+	name := names.GenerateResourceName("ruser", username)
+
+	return secretClient.Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/pkg/epinio/role.go
+++ b/pkg/epinio/role.go
@@ -107,3 +107,12 @@ func (k *KubeClient) CreateRole(ctx context.Context, role Role) error {
 
 	return nil
 }
+
+// DeleteRole deletes a role by id.
+func (k *KubeClient) DeleteRole(ctx context.Context, id string) error {
+	cmClient := k.kube.CoreV1().ConfigMaps("epinio")
+
+	name := names.GenerateResourceName("epinio", id, "role")
+
+	return cmClient.Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -107,6 +107,7 @@ func deleteEntity(t *testing.T, entityName string, args []string, expectError bo
 
 	deleteArgs := []string{"delete", entityArg}
 	deleteArgs = append(deleteArgs, args...)
+	deleteArgs = append(deleteArgs, "-y") // non-interactive mode
 
 	cmd := exec.Command(cmdExecPath(t), deleteArgs...)
 

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -1,0 +1,160 @@
+package tests
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteRole(t *testing.T) {
+	testCases := []struct {
+		name            string
+		createdRoleName string
+		args            []string
+		expectErr       bool
+	}{
+		{
+			name:            "delete existing role",
+			createdRoleName: "foo",
+			args:            []string{"foo"},
+			expectErr:       false,
+		},
+		{
+			name:            "delete nonexistent role",
+			createdRoleName: "foo",
+			args:            []string{"bar"},
+			expectErr:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			createArgs := []string{"create", "role", tc.createdRoleName}
+			cmd := exec.Command(cmdExecPath(t), createArgs...)
+
+			_, err := cmd.Output()
+			require.NoError(t, err)
+
+			if len(tc.args) == 0 || tc.createdRoleName != tc.args[0] {
+				defer deleteRole(t, []string{tc.createdRoleName}, false) // clean up created role
+			}
+
+			checkRoleExists(t, tc.createdRoleName, true)
+
+			deleteRole(t, tc.args, tc.expectErr)
+
+			checkRoleExists(t, tc.args[0], false)
+		})
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	testCases := []struct {
+		name            string
+		createdUserName string
+		args            []string
+		expectErr       bool
+	}{
+		{
+			name:            "delete existing user",
+			createdUserName: "foo",
+			args:            []string{"foo"},
+			expectErr:       false,
+		},
+		{
+			name:            "delete nonexistent user",
+			createdUserName: "foo",
+			args:            []string{"bar"},
+			expectErr:       true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			createArgs := []string{"create", "user", tc.createdUserName}
+			cmd := exec.Command(cmdExecPath(t), createArgs...)
+
+			_, err := cmd.Output()
+			require.NoError(t, err)
+
+			if len(tc.args) == 0 || tc.createdUserName != tc.args[0] {
+				defer deleteUser(t, []string{tc.createdUserName}, false) // clean up created user
+			}
+
+			checkUserExists(t, tc.createdUserName, true)
+
+			deleteUser(t, tc.args, tc.expectErr)
+
+			checkUserExists(t, tc.args[0], false)
+		})
+	}
+}
+
+func deleteRole(t *testing.T, args []string, expectError bool) {
+	deleteEntity(t, "role", args, expectError)
+}
+
+func deleteUser(t *testing.T, args []string, expectError bool) {
+	deleteEntity(t, "user", args, expectError)
+}
+
+func deleteEntity(t *testing.T, entityName string, args []string, expectError bool) {
+	entityArg := validateEntity(t, entityName)
+
+	deleteArgs := []string{"delete", entityArg}
+	deleteArgs = append(deleteArgs, args...)
+
+	cmd := exec.Command(cmdExecPath(t), deleteArgs...)
+
+	_, err := cmd.Output()
+	if expectError {
+		assert.Error(t, err)
+	} else {
+		assert.NoError(t, err)
+	}
+}
+
+func checkRoleExists(t *testing.T, name string, shouldBeFound bool) {
+	checkEntityExists(t, "role", name, shouldBeFound)
+}
+
+func checkUserExists(t *testing.T, name string, shouldBeFound bool) {
+	checkEntityExists(t, "user", name, shouldBeFound)
+}
+
+func checkEntityExists(t *testing.T, entityName string, name string, shouldBeFound bool) {
+	entityArg := validateEntity(t, entityName)
+
+	getArgs := []string{"get", entityArg}
+	cmd := exec.Command(cmdExecPath(t), getArgs...)
+
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	isFound := false
+
+	foundEntries := strings.Split(string(out), "\n")
+	for _, entry := range foundEntries {
+		if entry == name {
+			isFound = true
+			break
+		}
+	}
+
+	assert.Equal(t, shouldBeFound, isFound)
+}
+
+func validateEntity(t *testing.T, name string) string {
+	switch name {
+	case "user", "role":
+		return name
+	default:
+		assert.False(t, true, fmt.Sprintf("Got entity name %s, expecting role or user", name))
+	}
+
+	return ""
+}


### PR DESCRIPTION
Single roles and users can now be deleted via
`kubectl-epinio delete role <role_id>` and
`kubectl-epinio delete <username>`, respectively.

Both commands come with a non-interactive mode (flag `-y`), to skip prompts for confirmation before deletion.